### PR TITLE
Add support for all HTTP methods in Node.js binding

### DIFF
--- a/nodejs/examples/eventsource.js
+++ b/nodejs/examples/eventsource.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uws = require('./dist/uws');
+const uws = require('../dist/uws');
 
 // the page that will connect back over EventSource
 const document = '<script>var es = new EventSource(\'/eventSource\'); es.onmessage = function(message) {document.write(\'<p><b>Server sent event:</b> \' + message.data + \'</p>\');};</script>';

--- a/nodejs/examples/http.js
+++ b/nodejs/examples/http.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uws = require('./dist/uws');
+const uws = require('../dist/uws');
 
 const document = Buffer.from('Hello world!');
 

--- a/nodejs/examples/http_demo.js
+++ b/nodejs/examples/http_demo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uws = require('./dist/uws');
+const uws = require('../dist/uws');
 const document = Buffer.from('Hello world!');
 
 const server = uws.http.createServer((req, res) => {

--- a/nodejs/examples/http_sillybenchmark.js
+++ b/nodejs/examples/http_sillybenchmark.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uws = require('./dist/uws');
+const uws = require('../dist/uws');
 const document = Buffer.from('Hello world!');
 
 const server = uws.http.createServer((req, res) => {

--- a/nodejs/examples/koa.js
+++ b/nodejs/examples/koa.js
@@ -1,6 +1,6 @@
 var koa = require('koa');
 var app = koa();
-var uhttp = require('./dist/uws').http;
+var uhttp = require('../dist/uws').http;
 
 app.use(function *() {
   this.body = 'Hello World';

--- a/nodejs/examples/paths.js
+++ b/nodejs/examples/paths.js
@@ -1,7 +1,7 @@
 // example showing usage with different behavior on a path basis
 
 const http = require('http');
-const WebSocketServer = require('./dist/uws').Server;
+const WebSocketServer = require('../dist/uws').Server;
 
 const httpServer = http.createServer((request, response) => {
   response.end();

--- a/nodejs/examples/ssl.js
+++ b/nodejs/examples/ssl.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const fs = require('fs');
-const wsServer = require('./dist/uws').Server;
+const wsServer = require('../dist/uws').Server;
 
 const options = {
   key: fs.readFileSync('/home/alexhultman/µWebSockets.key.pem'),

--- a/nodejs/examples/test.js
+++ b/nodejs/examples/test.js
@@ -1,4 +1,4 @@
-var WebSocket = require('./dist/uws');
+var WebSocket = require('../dist/uws');
 var ws = new WebSocket('ws://echo.websocket.org');
 
 ws.on('open', function open() {

--- a/nodejs/src/http.h
+++ b/nodejs/src/http.h
@@ -37,7 +37,6 @@ struct HttpServer {
             args.GetReturnValue().Set(args.This()->GetInternalField(4));
         }
 
-        // todo: add all cases
         static void method(Local<String> property, const PropertyCallbackInfo<Value> &args) {
             //std::cout << "method" << std::endl;
             long methodId = ((long) args.This()->GetAlignedPointerFromInternalField(3)) >> 1;
@@ -45,8 +44,29 @@ struct HttpServer {
             case uWS::HttpMethod::METHOD_GET:
                 args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "GET", String::kNormalString, 3));
                 break;
+            case uWS::HttpMethod::METHOD_PUT:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "PUT", String::kNormalString, 3));
+                break;
             case uWS::HttpMethod::METHOD_POST:
                 args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "POST", String::kNormalString, 4));
+                break;
+            case uWS::HttpMethod::METHOD_HEAD:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "HEAD", String::kNormalString, 4));
+                break;
+            case uWS::HttpMethod::METHOD_PATCH:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "PATCH", String::kNormalString, 5));
+                break;
+            case uWS::HttpMethod::METHOD_TRACE:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "TRACE", String::kNormalString, 5));
+                break;
+            case uWS::HttpMethod::METHOD_DELETE:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "DELETE", String::kNormalString, 6));
+                break;
+            case uWS::HttpMethod::METHOD_OPTIONS:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "OPTIONS", String::kNormalString, 7));
+                break;
+            case uWS::HttpMethod::METHOD_CONNECT:
+                args.GetReturnValue().Set(String::NewFromOneByte(args.GetIsolate(), (uint8_t *) "CONNECT", String::kNormalString, 7));
                 break;
             }
         }


### PR DESCRIPTION
Add all HTTP methods to the Node.js binding.

Also some paths in the examples were broken, just relative folder changes. @alexhultman 